### PR TITLE
fix: 阿里小程序等<svg> 需要encodeUri操作， 提取部分公共代码

### DIFF
--- a/src/libs/generateAlipayComponent.ts
+++ b/src/libs/generateAlipayComponent.ts
@@ -23,6 +23,9 @@ export const generateAlipayComponent = (data: XmlData, config: Config) => {
   mkdirp.sync(saveDir);
   glob.sync(path.join(saveDir, '*')).forEach((file) => fs.unlinkSync(file));
 
+  /** 阿里小程序axml插入函数的语法 */
+  svgTemplates.push(`<import-sjs name="encode" from="./alipay.sjs"/>`)
+
   data.svg.symbol.forEach((item) => {
     const iconId = item.$.id;
     const iconIdAfterTrim = config.trim_icon_prefix
@@ -34,7 +37,9 @@ export const generateAlipayComponent = (data: XmlData, config: Config) => {
 
     names.push(iconIdAfterTrim);
     svgTemplates.push(
-      `<!--${iconIdAfterTrim}-->\n<view a:if="{{name === '${iconIdAfterTrim}'}}" style="background-image: url({{quot}}data:image/svg+xml, ${generateCase(item)}{{quot}});` +
+      `<!--${iconIdAfterTrim}-->\n<view a:if="{{name === '${iconIdAfterTrim}'}}" style="background-image: url({{quot}}data:image/svg+xml, ${generateCase(item, {
+        encodeSvg: true
+      })}{{quot}});` +
       ' width: {{svgSize}}px; height: {{svgSize}}px; " class="icon" />'
     );
 
@@ -42,6 +47,7 @@ export const generateAlipayComponent = (data: XmlData, config: Config) => {
   });
 
   fs.writeFileSync(path.join(saveDir, fileName + '.acss'), getTemplate('alipay.acss'));
+  fs.writeFileSync(path.join(saveDir, fileName + '.sjs'), getTemplate('alipay.sjs'));
   fs.writeFileSync(
     path.join(saveDir, fileName + '.axml'),
     svgTemplates.join('\n\n')

--- a/src/libs/generateAlipayComponent.ts
+++ b/src/libs/generateAlipayComponent.ts
@@ -24,7 +24,7 @@ export const generateAlipayComponent = (data: XmlData, config: Config) => {
   glob.sync(path.join(saveDir, '*')).forEach((file) => fs.unlinkSync(file));
 
   /** 阿里小程序axml插入函数的语法 */
-  svgTemplates.push(`<import-sjs name="encode" from="./alipay.sjs"/>`)
+  svgTemplates.push(`<import-sjs name="encode" from="./${fileName}.sjs"/>`)
 
   data.svg.symbol.forEach((item) => {
     const iconId = item.$.id;

--- a/src/libs/generateAlipayComponent.ts
+++ b/src/libs/generateAlipayComponent.ts
@@ -6,13 +6,13 @@ import colors from 'colors';
 import { XmlData } from './fetchXml';
 import { Config } from './getConfig';
 import { getTemplate } from './getTemplate';
+import { generateCase } from "./utils"
 import {
   replaceIsRpx,
   replaceNames,
   replaceSize,
 } from './replace';
 
-const ATTRIBUTE_FILL_MAP = ['path'];
 
 export const generateAlipayComponent = (data: XmlData, config: Config) => {
   const svgTemplates: string[] = [];
@@ -59,53 +59,3 @@ export const generateAlipayComponent = (data: XmlData, config: Config) => {
   console.log(`\n${colors.green('√')} All icons have been putted into dir: ${colors.green(config.save_dir)}\n`);
 };
 
-const generateCase = (data: XmlData['svg']['symbol'][number]) => {
-  let template = `<svg viewBox='${data.$.viewBox}' xmlns='http://www.w3.org/2000/svg' width='{{svgSize}}px' height='{{svgSize}}px'>`;
-
-  for (const domName of Object.keys(data)) {
-    if (domName === '$') {
-      continue;
-    }
-
-    const counter = {
-      colorIndex: 0,
-    };
-
-    if (data[domName].$) {
-      template += `<${domName}${addAttribute(domName, data[domName], counter)} />`;
-    } else if (Array.isArray(data[domName])) {
-      data[domName].forEach((sub) => {
-        template += `<${domName}${addAttribute(domName, sub, counter)} />`;
-      });
-    }
-  }
-
-  template += `</svg>`;
-
-  return template;
-};
-
-const addAttribute = (domName: string, sub: XmlData['svg']['symbol'][number]['path'][number], counter: { colorIndex: number }) => {
-  let template = '';
-
-  if (sub && sub.$) {
-    if (ATTRIBUTE_FILL_MAP.includes(domName)) {
-      // Set default color same as in iconfont.cn
-      // And create placeholder to inject color by user's behavior
-      sub.$.fill = sub.$.fill || '#333333';
-    }
-
-    for (const attributeName of Object.keys(sub.$)) {
-      if (attributeName === 'fill') {
-        const color = sub.$[attributeName];
-
-        template += ` ${attributeName}='{{(isStr ? color : color[${counter.colorIndex}]) || '${color}'}}'`;
-        counter.colorIndex += 1;
-      } else {
-        template += ` ${attributeName}='${sub.$[attributeName]}'`;
-      }
-    }
-  }
-
-  return template;
-};

--- a/src/libs/generateBaiduComponent.ts
+++ b/src/libs/generateBaiduComponent.ts
@@ -5,6 +5,7 @@ import glob from 'glob';
 import colors from 'colors';
 import { XmlData } from './fetchXml';
 import { Config } from './getConfig';
+import { generateCase } from "./utils"
 import { getTemplate } from './getTemplate';
 import {
   replaceIsRpx,
@@ -12,7 +13,6 @@ import {
   replaceSize,
 } from './replace';
 
-const ATTRIBUTE_FILL_MAP = ['path'];
 
 export const generateBaiduComponent = (data: XmlData, config: Config) => {
   const svgTemplates: string[] = [];
@@ -57,55 +57,4 @@ export const generateBaiduComponent = (data: XmlData, config: Config) => {
   fs.writeFileSync(path.join(saveDir, fileName + '.json'), getTemplate('baidu.json'));
 
   console.log(`\n${colors.green('√')} All icons have been putted into dir: ${colors.green(config.save_dir)}\n`);
-};
-
-const generateCase = (data: XmlData['svg']['symbol'][number]) => {
-  let template = `<svg viewBox='${data.$.viewBox}' xmlns='http://www.w3.org/2000/svg' width='{{svgSize}}px' height='{{svgSize}}px'>`;
-
-  for (const domName of Object.keys(data)) {
-    if (domName === '$') {
-      continue;
-    }
-
-    const counter = {
-      colorIndex: 0,
-    };
-
-    if (data[domName].$) {
-      template += `<${domName}${addAttribute(domName, data[domName], counter)} />`;
-    } else if (Array.isArray(data[domName])) {
-      data[domName].forEach((sub) => {
-        template += `<${domName}${addAttribute(domName, sub, counter)} />`;
-      });
-    }
-  }
-
-  template += `</svg>`;
-
-  return template;
-};
-
-const addAttribute = (domName: string, sub: XmlData['svg']['symbol'][number]['path'][number], counter: { colorIndex: number }) => {
-  let template = '';
-
-  if (sub && sub.$) {
-    if (ATTRIBUTE_FILL_MAP.includes(domName)) {
-      // Set default color same as in iconfont.cn
-      // And create placeholder to inject color by user's behavior
-      sub.$.fill = sub.$.fill || '#333333';
-    }
-
-    for (const attributeName of Object.keys(sub.$)) {
-      if (attributeName === 'fill') {
-        const color = sub.$[attributeName];
-
-        template += ` ${attributeName}='{{(isStr ? color : color[${counter.colorIndex}]) || '${color}'}}'`;
-        counter.colorIndex += 1;
-      } else {
-        template += ` ${attributeName}='${sub.$[attributeName]}'`;
-      }
-    }
-  }
-
-  return template;
 };

--- a/src/libs/generateKuaishouComponent.ts
+++ b/src/libs/generateKuaishouComponent.ts
@@ -6,14 +6,13 @@ import colors from 'colors';
 import { Config } from './getConfig';
 import { XmlData } from './fetchXml';
 import { getTemplate } from './getTemplate';
+import { generateCase } from "./utils"
 import {
   replaceNames,
   replaceSize,
   replaceIsRpx,
-  replaceHexToRgb
 } from './replace';
 
-const ATTRIBUTE_FILL_MAP = ['path'];
 
 export const generateKuaishouComponent = (data: XmlData, config: Config) => {
   const names: string[] = [];
@@ -36,7 +35,9 @@ export const generateKuaishouComponent = (data: XmlData, config: Config) => {
 
     names.push(iconIdAfterTrim);
     svgTemplates.push(
-      `<!--${iconIdAfterTrim}-->\n<view ks:if="{{name === '${iconIdAfterTrim}'}}" style="background-image: url({{quot}}data:image/svg+xml, ${generateCase(item)}{{quot}});` +
+      `<!--${iconIdAfterTrim}-->\n<view ks:if="{{name === '${iconIdAfterTrim}'}}" style="background-image: url({{quot}}data:image/svg+xml, ${generateCase(item, {
+        hexToRgb: true
+      })}{{quot}});` +
       ' width: {{svgSize}}px; height: {{svgSize}}px;" class="icon" />'
     );
 
@@ -54,55 +55,4 @@ export const generateKuaishouComponent = (data: XmlData, config: Config) => {
   fs.writeFileSync(path.join(saveDir, fileName + '.js'), jsFile);
 
   console.log(`\n${colors.green('√')} All icons have been putted into dir: ${colors.green(config.save_dir)}\n`);
-};
-
-const generateCase = (data: XmlData['svg']['symbol'][number]) => {
-  let template = `<svg viewBox='${data.$.viewBox}' xmlns='http://www.w3.org/2000/svg' width='{{svgSize}}px' height='{{svgSize}}px'>`;
-
-  for (const domName of Object.keys(data)) {
-    if (domName === '$') {
-      continue;
-    }
-
-    const counter = {
-      colorIndex: 0,
-    };
-
-    if (data[domName].$) {
-      template += `<${domName}${addAttribute(domName, data[domName], counter)} />`;
-    } else if (Array.isArray(data[domName])) {
-      data[domName].forEach((sub) => {
-        template += `<${domName}${addAttribute(domName, sub, counter)} />`;
-      });
-    }
-  }
-
-  template += `</svg>`;
-
-  return template.replace(/<|>/g, (matched) => encodeURI(matched));
-};
-
-const addAttribute = (domName: string, sub: XmlData['svg']['symbol'][number]['path'][number], counter: { colorIndex: number }) => {
-  let template = '';
-
-  if (sub && sub.$) {
-    if (ATTRIBUTE_FILL_MAP.includes(domName)) {
-      // Set default color same as in iconfont.cn
-      // And create placeholder to inject color by user's behavior
-      sub.$.fill = sub.$.fill || '#333333';
-    }
-
-    for (const attributeName of Object.keys(sub.$)) {
-      if (attributeName === 'fill') {
-        const color = replaceHexToRgb(sub.$[attributeName]);
-
-        template += ` ${attributeName}='{{(isStr ? colors : colors[${counter.colorIndex}]) || '${color}'}}'`;
-        counter.colorIndex += 1;
-      } else {
-        template += ` ${attributeName}='${sub.$[attributeName]}'`;
-      }
-    }
-  }
-
-  return template;
 };

--- a/src/libs/generateQqComponent.ts
+++ b/src/libs/generateQqComponent.ts
@@ -6,6 +6,7 @@ import colors from 'colors';
 import { XmlData } from './fetchXml';
 import { Config } from './getConfig';
 import { getTemplate } from './getTemplate';
+import { generateCase } from "./utils"
 import {
   replaceIsRpx,
   replaceNames,
@@ -13,7 +14,6 @@ import {
 } from './replace';
 // import { whitespace } from './whitespace';
 
-const ATTRIBUTE_FILL_MAP = ['path'];
 
 export const generateQqComponent = (data: XmlData, config: Config) => {
   const svgTemplates: string[] = [];
@@ -58,55 +58,4 @@ export const generateQqComponent = (data: XmlData, config: Config) => {
   fs.writeFileSync(path.join(saveDir, fileName + '.json'), getTemplate('qq.json'));
 
   console.log(`\n${colors.green('√')} All icons have been putted into dir: ${colors.green(config.save_dir)}\n`);
-};
-
-const generateCase = (data: XmlData['svg']['symbol'][number]) => {
-  let template = `<svg viewBox='${data.$.viewBox}' xmlns='http://www.w3.org/2000/svg' width='{{svgSize}}px' height='{{svgSize}}px'>`;
-
-  for (const domName of Object.keys(data)) {
-    if (domName === '$') {
-      continue;
-    }
-
-    const counter = {
-      colorIndex: 0,
-    };
-
-    if (data[domName].$) {
-      template += `<${domName}${addAttribute(domName, data[domName], counter)} />`;
-    } else if (Array.isArray(data[domName])) {
-      data[domName].forEach((sub) => {
-        template += `<${domName}${addAttribute(domName, sub, counter)} />`;
-      });
-    }
-  }
-
-  template += `</svg>`;
-
-  return template.replace(/<|>/g, (matched) => encodeURI(matched));
-};
-
-const addAttribute = (domName: string, sub: XmlData['svg']['symbol'][number]['path'][number], counter: { colorIndex: number }) => {
-  let template = '';
-
-  if (sub && sub.$) {
-    if (ATTRIBUTE_FILL_MAP.includes(domName)) {
-      // Set default color same as in iconfont.cn
-      // And create placeholder to inject color by user's behavior
-      sub.$.fill = sub.$.fill || '#333333';
-    }
-
-    for (const attributeName of Object.keys(sub.$)) {
-      if (attributeName === 'fill') {
-        const color = sub.$[attributeName];
-
-        template += ` ${attributeName}='{{(isStr ? color : color[${counter.colorIndex}]) || '${color}'}}'`;
-        counter.colorIndex += 1;
-      } else {
-        template += ` ${attributeName}='${sub.$[attributeName]}'`;
-      }
-    }
-  }
-
-  return template;
 };

--- a/src/libs/generateToutiaoComponent.ts
+++ b/src/libs/generateToutiaoComponent.ts
@@ -6,13 +6,13 @@ import colors from 'colors';
 import { XmlData } from './fetchXml';
 import { Config } from './getConfig';
 import { getTemplate } from './getTemplate';
+import { generateCase } from "./utils"
 import {
   replaceIsRpx,
   replaceNames,
   replaceSize,
 } from './replace';
 
-const ATTRIBUTE_FILL_MAP = ['path'];
 
 export const generateToutiaoComponent = (data: XmlData, config: Config) => {
   const svgTemplates: string[] = [];
@@ -57,55 +57,4 @@ export const generateToutiaoComponent = (data: XmlData, config: Config) => {
   fs.writeFileSync(path.join(saveDir, fileName + '.json'), getTemplate('toutiao.json'));
 
   console.log(`\n${colors.green('√')} All icons have been putted into dir: ${colors.green(config.save_dir)}\n`);
-};
-
-const generateCase = (data: XmlData['svg']['symbol'][number]) => {
-  let template = `<svg viewBox='${data.$.viewBox}' xmlns='http://www.w3.org/2000/svg' width='{{svgSize}}px' height='{{svgSize}}px'>`;
-
-  for (const domName of Object.keys(data)) {
-    if (domName === '$') {
-      continue;
-    }
-
-    const counter = {
-      colorIndex: 0,
-    };
-
-    if (data[domName].$) {
-      template += `<${domName}${addAttribute(domName, data[domName], counter)} />`;
-    } else if (Array.isArray(data[domName])) {
-      data[domName].forEach((sub) => {
-        template += `<${domName}${addAttribute(domName, sub, counter)} />`;
-      });
-    }
-  }
-
-  template += `</svg>`;
-
-  return template;
-};
-
-const addAttribute = (domName: string, sub: XmlData['svg']['symbol'][number]['path'][number], counter: { colorIndex: number }) => {
-  let template = '';
-
-  if (sub && sub.$) {
-    if (ATTRIBUTE_FILL_MAP.includes(domName)) {
-      // Set default color same as in iconfont.cn
-      // And create placeholder to inject color by user's behavior
-      sub.$.fill = sub.$.fill || '#333333';
-    }
-
-    for (const attributeName of Object.keys(sub.$)) {
-      if (attributeName === 'fill') {
-        const color = sub.$[attributeName];
-
-        template += ` ${attributeName}='{{(isStr ? color : color[${counter.colorIndex}]) || '${color}'}}'`;
-        counter.colorIndex += 1;
-      } else {
-        template += ` ${attributeName}='${sub.$[attributeName]}'`;
-      }
-    }
-  }
-
-  return template;
 };

--- a/src/libs/generateWechatComponent.ts
+++ b/src/libs/generateWechatComponent.ts
@@ -6,14 +6,14 @@ import colors from 'colors';
 import { XmlData } from './fetchXml';
 import { Config } from './getConfig';
 import { getTemplate } from './getTemplate';
+import { generateCase } from "./utils"
 import {
-  replaceHexToRgb, replaceIsRpx,
+   replaceIsRpx,
   replaceNames,
   replaceSize,
 } from './replace';
 // import { whitespace } from './whitespace';
 
-const ATTRIBUTE_FILL_MAP = ['path'];
 
 export const generateWechatComponent = (data: XmlData, config: Config) => {
   const svgTemplates: string[] = [];
@@ -35,7 +35,9 @@ export const generateWechatComponent = (data: XmlData, config: Config) => {
 
     names.push(iconIdAfterTrim);
     svgTemplates.push(
-      `<!--${iconIdAfterTrim}-->\n<view wx:if="{{name === '${iconIdAfterTrim}'}}" style="background-image: url({{quot}}data:image/svg+xml, ${generateCase(item)}{{quot}});` +
+      `<!--${iconIdAfterTrim}-->\n<view wx:if="{{name === '${iconIdAfterTrim}'}}" style="background-image: url({{quot}}data:image/svg+xml, ${generateCase(item, {
+        hexToRgb: true
+      })}{{quot}});` +
       ' width: {{svgSize}}px; height: {{svgSize}}px; " class="icon" />'
     );
 
@@ -60,53 +62,3 @@ export const generateWechatComponent = (data: XmlData, config: Config) => {
   console.log(`\n${colors.green('√')} All icons have been putted into dir: ${colors.green(config.save_dir)}\n`);
 };
 
-const generateCase = (data: XmlData['svg']['symbol'][number]) => {
-  let template = `<svg viewBox='${data.$.viewBox}' xmlns='http://www.w3.org/2000/svg' width='{{svgSize}}px' height='{{svgSize}}px'>`;
-
-  for (const domName of Object.keys(data)) {
-    if (domName === '$') {
-      continue;
-    }
-
-    const counter = {
-      colorIndex: 0,
-    };
-
-    if (data[domName].$) {
-      template += `<${domName}${addAttribute(domName, data[domName], counter)} />`;
-    } else if (Array.isArray(data[domName])) {
-      data[domName].forEach((sub) => {
-        template += `<${domName}${addAttribute(domName, sub, counter)} />`;
-      });
-    }
-  }
-
-  template += `</svg>`;
-
-  return template.replace(/<|>/g, (matched) => encodeURI(matched));
-};
-
-const addAttribute = (domName: string, sub: XmlData['svg']['symbol'][number]['path'][number], counter: { colorIndex: number }) => {
-  let template = '';
-
-  if (sub && sub.$) {
-    if (ATTRIBUTE_FILL_MAP.includes(domName)) {
-      // Set default color same as in iconfont.cn
-      // And create placeholder to inject color by user's behavior
-      sub.$.fill = sub.$.fill || '#333333';
-    }
-
-    for (const attributeName of Object.keys(sub.$)) {
-      if (attributeName === 'fill') {
-        const color = replaceHexToRgb(sub.$[attributeName]);
-
-        template += ` ${attributeName}='{{(isStr ? colors : colors[${counter.colorIndex}]) || '${color}'}}'`;
-        counter.colorIndex += 1;
-      } else {
-        template += ` ${attributeName}='${sub.$[attributeName]}'`;
-      }
-    }
-  }
-
-  return template;
-};

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -1,0 +1,65 @@
+import {XmlData} from "./fetchXml";
+import {replaceHexToRgb} from "./replace";
+
+const ATTRIBUTE_FILL_MAP = ['path'];
+
+
+export const generateCase = (data: XmlData['svg']['symbol'][number], config?: {
+  hexToRgb?:boolean
+}) => {
+  let template = `<svg viewBox='${data.$.viewBox}' xmlns='http://www.w3.org/2000/svg' width='{{svgSize}}px' height='{{svgSize}}px'>`;
+
+  for (const domName of Object.keys(data)) {
+    if (domName === '$') {
+      continue;
+    }
+
+    const counter = {
+      colorIndex: 0,
+    };
+
+    if (data[domName].$) {
+      template += `<${domName}${addAttribute(domName, data[domName], counter, config)} />`;
+    } else if (Array.isArray(data[domName])) {
+      data[domName].forEach((sub) => {
+        template += `<${domName}${addAttribute(domName, sub, counter, config)} />`;
+      });
+    }
+  }
+
+  template += `</svg>`;
+
+  return template.replace(/<|>/g, (matched) => encodeURI(matched));
+};
+
+const addAttribute = (domName: string, sub: XmlData['svg']['symbol'][number]['path'][number], counter: { colorIndex: number },  config?: {
+  hexToRgb?:boolean
+}) => {
+  let template = '';
+
+  if (sub && sub.$) {
+    if (ATTRIBUTE_FILL_MAP.includes(domName)) {
+      // Set default color same as in iconfont.cn
+      // And create placeholder to inject color by user's behavior
+      sub.$.fill = sub.$.fill || '#333333';
+    }
+
+    for (const attributeName of Object.keys(sub.$)) {
+      if (attributeName === 'fill') {
+        let color :string | undefined;
+        if(config?.hexToRgb){
+          color = replaceHexToRgb(sub.$[attributeName]);
+        }else {
+          color = sub.$[attributeName]
+        }
+
+        template += ` ${attributeName}='{{(isStr ? colors : colors[${counter.colorIndex}]) || '${color}'}}'`;
+        counter.colorIndex += 1;
+      } else {
+        template += ` ${attributeName}='${sub.$[attributeName]}'`;
+      }
+    }
+  }
+
+  return template;
+};

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -55,14 +55,16 @@ const addAttribute = (domName: string, sub: XmlData['svg']['symbol'][number]['pa
     for (const attributeName of Object.keys(sub.$)) {
       if (attributeName === 'fill') {
         let color :string | undefined;
+        let keyword: string;
         if(config?.hexToRgb){
           color = replaceHexToRgb(sub.$[attributeName]);
-          template += ` ${attributeName}='{{(isStr ? colors : colors[${counter.colorIndex}]) || '${color}'}}'`;
+          keyword = 'colors'
           counter.colorIndex += 1;
         }else {
+          keyword = 'color'
           color = sub.$[attributeName]
-          template += ` ${attributeName}='{{color}}'`;
         }
+        template += ` ${attributeName}='{{(isStr ? ${keyword} : ${keyword}[${counter.colorIndex}]) || '${color}'}}'`;
 
       } else {
         template += ` ${attributeName}='${sub.$[attributeName]}'`;

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -5,7 +5,8 @@ const ATTRIBUTE_FILL_MAP = ['path'];
 
 
 export const generateCase = (data: XmlData['svg']['symbol'][number], config?: {
-  hexToRgb?:boolean
+  hexToRgb?:boolean,
+  encodeSvg?: boolean;
 }) => {
   let template = `<svg viewBox='${data.$.viewBox}' xmlns='http://www.w3.org/2000/svg' width='{{svgSize}}px' height='{{svgSize}}px'>`;
 
@@ -28,8 +29,15 @@ export const generateCase = (data: XmlData['svg']['symbol'][number], config?: {
   }
 
   template += `</svg>`;
+  if(config?.encodeSvg) {
+    /** 将 '%7B%7Bx%7D%7D'格式的文件 还原为 {{ x }}, 并encode*/
+    return encodeURIComponent(template).replace( /%7B%7B([\s\S]*?)%7D%7D/g,
+      (_, p1) => {
+        return `{{ encode.encode(${decodeURIComponent(p1)}) }}`;
+      })
+  }
 
-  return template.replace(/<|>/g, (matched) => encodeURI(matched));
+  return template.replace(/<|>/g, (matched) => encodeURIComponent(matched));
 };
 
 const addAttribute = (domName: string, sub: XmlData['svg']['symbol'][number]['path'][number], counter: { colorIndex: number },  config?: {

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -57,7 +57,7 @@ const addAttribute = (domName: string, sub: XmlData['svg']['symbol'][number]['pa
         let color :string | undefined;
         if(config?.hexToRgb){
           color = replaceHexToRgb(sub.$[attributeName]);
-          template += `${attributeName}='{{(isStr ? colors : colors[${counter.colorIndex}]) || '${color}'}}'`;
+          template += ` ${attributeName}='{{(isStr ? colors : colors[${counter.colorIndex}]) || '${color}'}}'`;
           counter.colorIndex += 1;
         }else {
           color = sub.$[attributeName]

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -57,12 +57,13 @@ const addAttribute = (domName: string, sub: XmlData['svg']['symbol'][number]['pa
         let color :string | undefined;
         if(config?.hexToRgb){
           color = replaceHexToRgb(sub.$[attributeName]);
+          template += `${attributeName}='{{(isStr ? colors : colors[${counter.colorIndex}]) || '${color}'}}'`;
+          counter.colorIndex += 1;
         }else {
           color = sub.$[attributeName]
+          template += ` ${attributeName}='{{color}}'`;
         }
 
-        template += ` ${attributeName}='{{(isStr ? colors : colors[${counter.colorIndex}]) || '${color}'}}'`;
-        counter.colorIndex += 1;
       } else {
         template += ` ${attributeName}='${sub.$[attributeName]}'`;
       }

--- a/src/templates/alipay.sjs.template
+++ b/src/templates/alipay.sjs.template
@@ -1,0 +1,5 @@
+const encode = (str)=> encodeURIComponent(str);
+
+export default {
+  encode
+};


### PR DESCRIPTION
## 阿里、头条等小程序端增加<svg> encodeUri操作， 提取部分公共代码

作者你好：

我使用[remax-iconfont-cli](https://github.com/iconfont-cli/remax-iconfont-cli)进行阿里小程序icon组件生成时，无法正确显示图标， 经查看得知原因是在于生成的 base64的svg图片无法正常显示。

生成的格式为这个样式：（因为<>符号未进行encodeURI操作, 所以无法正确显示）
```
data:image/svg+xml, <svg viewBox='0 0 1024 1024' xmlns='http://www.w3.org/2000/svg' width='16px' height='16px'><path d='M571.134948 546.559968a59.134953 59.134953 0 1 1-118.269906 0V270.852186a59.134953 59.134953 0 1 1 118.269906 0zM511.999995 802.552765a58.878953 58.878953 0 1 1 41.726967-17.150986A57.086955 57.086955 0 0 1 511.999995 802.553765zM511.999995 0.0104a501.749603 501.749603 0 0 0-199.419842 39.935968A509.685597 509.685597 0 0 0 39.946368 312.580153 501.749603 501.749603 0 0 0 0.0104 511.999995a501.749603 501.749603 0 0 0 39.935968 199.419842A509.685597 509.685597 0 0 0 312.580153 984.054622 501.749603 501.749603 0 0 0 511.999995 1023.98959a501.749603 501.749603 0 0 0 199.419842-39.934968A509.685597 509.685597 0 0 0 984.054622 711.419837 501.749603 501.749603 0 0 0 1023.98959 511.999995a501.749603 501.749603 0 0 0-39.934968-199.419842A509.685597 509.685597 0 0 0 711.419837 39.946368 501.749603 501.749603 0 0 0 511.999995 0.0104z' fill='#FABD52' /></svg>
```



经查看源码得知 **remax-iconfont-cli**  依赖于仓库，其中生成阿里小程序的template时，没有进行encodeURI的操作。

这个pr用于修复阿里小程序的问题， 同时抽离了部分公共代码（对于 replaceHexToRgb 这个方法， wechat、头条等平台使用了，其他平台没有使用，因此我这里根据源码做了重构，保留了平台区分）。
 
希望尽快修复此bug, 目前公司项目依赖于本框架~ 谢谢！
